### PR TITLE
Add hammer modes

### DIFF
--- a/data/test/SimpleAlgebra.thy
+++ b/data/test/SimpleAlgebra.thy
@@ -20,8 +20,8 @@ proof -
   proof (simp add: algebra_simps eval_nat_numeral)
     have "(2 * (sqrt 2 * sqrt 3))^2 < 5 ^ 2"
       by (simp add: algebra_simps eval_nat_numeral)
-    then show "2 * (sqrt 2 * sqrt 3) < 5" sledgehammer
-      (* by (smt (verit, best) power_mono) *)
+    then show "2 * (sqrt 2 * sqrt 3) < 5"
+      by (smt (verit, best) power_mono)
   qed
   then show ?thesis
     by (simp add: real_less_rsqrt)

--- a/src/main/config.py
+++ b/src/main/config.py
@@ -76,7 +76,7 @@ class PromptSettings(object):
 @dataclass
 class EvalSettings(object):
     name: str
-    use_hammer: bool
+    use_hammer: ProofAction.HammerMode
     setting_type: SettingType = SettingType.Agent
     max_proof_depth: int = 50
     timeout_in_secs: int = 60
@@ -180,7 +180,7 @@ def parse_config(cfg):
     eval_settings_cfg = cfg["eval_settings"]
     eval_settings = EvalSettings(
         name=eval_settings_cfg["name"],
-        use_hammer=eval_settings_cfg["use_hammer"],
+        use_hammer=ProofAction.HammerMode(eval_settings_cfg["use_hammer"]),
         setting_type=SettingType(eval_settings_cfg["setting_type"]),
         max_proof_depth=eval_settings_cfg["max_proof_depth"],
         timeout_in_secs=eval_settings_cfg["timeout_in_secs"],

--- a/src/main/config/eval_settings/n_10_dfs_gpt35.yaml
+++ b/src/main/config/eval_settings/n_10_dfs_gpt35.yaml
@@ -1,6 +1,6 @@
 name: n_10_dfs_gpt35
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_10_dfs_gpt35_always_retrieve.yaml
+++ b/src/main/config/eval_settings/n_10_dfs_gpt35_always_retrieve.yaml
@@ -1,6 +1,6 @@
 name: n_10_dfs_gpt35_always_retrieve
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_120_dfs_gpt4_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_120_dfs_gpt4_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_120_dfs_gpt4_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 200
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_30_dfs_gpt35.yaml
+++ b/src/main/config/eval_settings/n_30_dfs_gpt35.yaml
@@ -1,6 +1,6 @@
 name: n_30_dfs_gpt35
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 30
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_30_dfs_gpt35_7_per_cent.yaml
+++ b/src/main/config/eval_settings/n_30_dfs_gpt35_7_per_cent.yaml
@@ -1,6 +1,6 @@
 name: n_30_dfs_gpt35_7_per_cent
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 30
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_30_dfs_gpt35_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_30_dfs_gpt35_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_30_dfs_gpt35_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_30_dfs_gpt35_h_7_per_cent.yaml
+++ b/src/main/config/eval_settings/n_30_dfs_gpt35_h_7_per_cent.yaml
@@ -1,6 +1,6 @@
 name: n_30_dfs_gpt35_h_7_per_cent
 setting_type: Agent
-use_hammer: True
+use_hammer: AUTO
 max_proof_depth: 30
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_30_dfs_gpt4.yaml
+++ b/src/main/config/eval_settings/n_30_dfs_gpt4.yaml
@@ -1,6 +1,6 @@
 name: n_30_dfs_gpt4
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 30
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_30_dfs_gpt4_7_per_cent.yaml
+++ b/src/main/config/eval_settings/n_30_dfs_gpt4_7_per_cent.yaml
@@ -1,6 +1,6 @@
 name: n_30_dfs_gpt4_7_per_cent
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 30
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_30_dfs_gpt4_always_retrieve.yaml
+++ b/src/main/config/eval_settings/n_30_dfs_gpt4_always_retrieve.yaml
@@ -1,6 +1,6 @@
 name: n_30_dfs_gpt4_always_retrieve
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_30_dfs_gpt4_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_30_dfs_gpt4_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_30_dfs_gpt4_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_40_dfs_gpt35_7_per_cent.yaml
+++ b/src/main/config/eval_settings/n_40_dfs_gpt35_7_per_cent.yaml
@@ -1,6 +1,6 @@
 name: n_40_dfs_gpt35_7_per_cent
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 40
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_40_dfs_gpt4_7_per_cent.yaml
+++ b/src/main/config/eval_settings/n_40_dfs_gpt4_7_per_cent.yaml
@@ -1,6 +1,6 @@
 name: n_40_dfs_gpt4_7_per_cent
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 40
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_4_few_codellama.yaml
+++ b/src/main/config/eval_settings/n_4_few_codellama.yaml
@@ -1,6 +1,6 @@
 name: n_4_few_codellama
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_4_few_gpt35.yaml
+++ b/src/main/config/eval_settings/n_4_few_gpt35.yaml
@@ -1,6 +1,6 @@
 name: n_4_few_gpt35
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_4_few_gpt35_7_per_cent.yaml
+++ b/src/main/config/eval_settings/n_4_few_gpt35_7_per_cent.yaml
@@ -1,6 +1,6 @@
 name: n_4_few_gpt35_7_per_cent
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_4_few_gpt4.yaml
+++ b/src/main/config/eval_settings/n_4_few_gpt4.yaml
@@ -1,6 +1,6 @@
 name: n_4_few_gpt4
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_4_few_gpt4_7_per_cent.yaml
+++ b/src/main/config/eval_settings/n_4_few_gpt4_7_per_cent.yaml
@@ -1,6 +1,6 @@
 name: n_4_few_gpt4_7_per_cent
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_4_few_gpt4_turbo.yaml
+++ b/src/main/config/eval_settings/n_4_few_gpt4_turbo.yaml
@@ -1,6 +1,6 @@
 name: n_4_few_gpt4_turbo
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_4_informal_gpt35.yaml
+++ b/src/main/config/eval_settings/n_4_informal_gpt35.yaml
@@ -1,6 +1,6 @@
 name: n_4_informal_gpt35
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_4_informal_gpt4_turbo.yaml
+++ b/src/main/config/eval_settings/n_4_informal_gpt4_turbo.yaml
@@ -1,6 +1,6 @@
 name: n_4_informal_gpt4_turbo
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_500_dfs_codellama_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_500_dfs_codellama_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_500_dfs_codellama_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 500
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_500_dfs_llemma_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_500_dfs_llemma_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_500_dfs_llemma_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 500
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_500_dfs_morph_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_500_dfs_morph_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_500_dfs_morph_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 500
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_50_dfs_gpt35.yaml
+++ b/src/main/config/eval_settings/n_50_dfs_gpt35.yaml
@@ -1,6 +1,6 @@
 name: n_50_dfs_gpt35
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 50
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt35_always_retrieve.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt35_always_retrieve.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt35_always_retrieve
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt35_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt35_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt35_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt35_no_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt35_no_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt35_no_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt4_0314_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt4_0314_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt4_0314_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt4_0314_no_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt4_0314_no_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt4_0314_no_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt4_0613_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt4_0613_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt4_0613_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt4_0613_no_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt4_0613_no_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt4_0613_no_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt4_128k_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt4_128k_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt4_128k_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt4_128k_no_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt4_128k_no_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt4_128k_no_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt4_always_retrieve.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt4_always_retrieve.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt4_always_retrieve
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt4_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt4_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt4_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: False
+use_hammer: ALLOW
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/rl/proof_action.py
+++ b/src/rl/proof_action.py
@@ -67,6 +67,15 @@ class ProofAction(Action):
             assert isinstance(other, ProofAction.ActionType), f"other must be of type ProofAction.ActionType, not {type(other)}"
             return ProofAction.ActionType.get_order(self) >= ProofAction.ActionType.get_order(other)
 
+    class HammerMode(Enum):
+        NONE = 'NONE'
+        ALLOW = 'ALLOW'
+        AUTO = 'AUTO'
+        ONESHOT = 'ONESHOT'
+
+        def __str__(self):
+            return self.name
+    
     action_type: ActionType
     language: Language
     kwargs: typing.Optional[dict] = field(default_factory=dict)

--- a/src/rl/proof_action.py
+++ b/src/rl/proof_action.py
@@ -68,10 +68,10 @@ class ProofAction(Action):
             return ProofAction.ActionType.get_order(self) >= ProofAction.ActionType.get_order(other)
 
     class HammerMode(Enum):
-        NONE = 'NONE'
-        ALLOW = 'ALLOW'
-        AUTO = 'AUTO'
-        ONESHOT = 'ONESHOT'
+        NONE = 'NONE' # Prohibit hammer
+        ALLOW = 'ALLOW' # Allow agent to query hammer
+        AUTO = 'AUTO' # Automatically apply hammer (heuristically)
+        ONESHOT = 'ONESHOT' # Proof attempt in one shot using hammer
 
         def __str__(self):
             return self.name

--- a/src/rl/simple_proof_env.py
+++ b/src/rl/simple_proof_env.py
@@ -580,7 +580,7 @@ if __name__ == "__main__":
             project_folder="data/test",
             file_path="data/test/SimpleAlgebra.thy",
             language=ProofAction.Language.ISABELLE,
-            use_hammer=True
+            use_hammer=ProofAction.HammerMode.AUTO
         )
         theorem_name = "sqrt_comp"
         language = ProofAction.Language.ISABELLE

--- a/src/tools/coq_raw_proofs.py
+++ b/src/tools/coq_raw_proofs.py
@@ -9,6 +9,7 @@ import logging
 import os
 import typing
 import ray
+from src.rl.proof_action import ProofAction
 from src.tools.ray_utils import RayUtils
 from src.tools.coq_parse_utils import CoqLineByLineReader
 from src.tools.training_data_format import Goal, TrainingDataFormat, TrainingDataMetadataFormat
@@ -88,7 +89,6 @@ def dump_raw_proofs(repo_builder: CoqRepoBuilder, output_dir: str, logger: loggi
                     coq_proof_exec_callback = ProofExecutorCallback(
                         project_folder=project_path,
                         file_path=file_path,
-                        use_hammer=False,
                         timeout_in_secs=60,
                         use_human_readable_proof_context=True,
                         suppress_error_log=True,

--- a/src/tools/dynamic_isabelle_proof_exec.py
+++ b/src/tools/dynamic_isabelle_proof_exec.py
@@ -10,6 +10,7 @@ import os
 import copy
 import enum
 import logging
+from src.rl.proof_action import ProofAction
 from src.tools.training_data_format import Goal, TrainingDataFormat
 from src.tools.isabelle_parse_utils import IsabelleLineByLineReader
 from src.tools.isabelle_executor import IsabelleExecutor
@@ -87,7 +88,7 @@ class DynamicProofExecutor(IsabelleExecutor):
             return -1
 
 
-    def __init__(self, isabelle_context_helper: IsabelleContextHelper, project_folder: str = None, proof_file: str = None, instruction_iter: typing.Optional[str] = None, use_hammer: bool = False, timeout_in_seconds: int = 60, use_human_readable_proof_context: bool = True, suppress_error_log: bool = True, context_type: ContextType = ContextType.NoContext):
+    def __init__(self, isabelle_context_helper: IsabelleContextHelper, project_folder: str = None, proof_file: str = None, instruction_iter: typing.Optional[str] = None, use_hammer: ProofAction.HammerMode = ProofAction.HammerMode.ALLOW, timeout_in_seconds: int = 60, use_human_readable_proof_context: bool = True, suppress_error_log: bool = True, context_type: ContextType = ContextType.NoContext):
         assert proof_file is None or os.path.exists(proof_file), f"Proof file {proof_file} does not exist"
         assert isabelle_context_helper is not None, "isabelle_context_helper must not be None"
         self.proof_file = proof_file

--- a/src/tools/dynamic_isabelle_proof_exec.py
+++ b/src/tools/dynamic_isabelle_proof_exec.py
@@ -185,11 +185,12 @@ class DynamicProofExecutor(IsabelleExecutor):
         start_line_num = self.line_num
         self.run_state.line_tactic_map[self.line_num] = len(self.run_state.tatics_ran)
         self.run_state.line_proof_context_map[self.line_num] = copy.deepcopy(self.proof_context)
-        for tactic in tactics:
+        for idx, tactic in enumerate(tactics):
             self.tactic_switch_iterator.set_next_instruction(tactic)
             try:
-                self.run_next()
-                self.run_state.tatics_ran.append(tactic)
+                actual_tactic = self.run_next()
+                tactics[idx] = actual_tactic
+                self.run_state.tatics_ran.append(actual_tactic)
                 self.run_state.line_proof_context_map[self.line_num] = copy.deepcopy(self.proof_context)
             except Exception as e:
                 self.line_num -= 1

--- a/src/tools/isabelle_executor.py
+++ b/src/tools/isabelle_executor.py
@@ -571,7 +571,7 @@ class IsabelleExecutor:
             return None
 
         tactics = re.split(r'(sledgehammer)', step)
-        tactics = list(filter(None, [t.strip() for t in tactics]))
+        tactics = list(filter(None, tactics))
         
         description = None
         stmt = ""
@@ -587,13 +587,13 @@ class IsabelleExecutor:
  
                 # Attempt to solve proof with sledgehammer
                 description = self._handle_auto_tactics(temp_start, temp_end)
-                stmt += description + ' ' # Replace with hammer-provided tactic, not 'sledgehammer' literally
+                stmt += description # Replace with hammer-provided tactic, not 'sledgehammer' literally
             else:
                 # Run tactic normally
                 description = self.pisa_env.step(temp_start, tactic, temp_end)
                 if description.startswith('Step error:'):
                     raise Exception(description)
-                stmt += tactic + ' '
+                stmt += tactic
 
         return stmt
     
@@ -609,7 +609,7 @@ class IsabelleExecutor:
         description = self.pisa_env.apply_hammer(start_state, end_state)
         if description.startswith('Step error:'):
             raise Exception(description)
-        return description.split("<hammer>")[0] + "<hammer>"
+        return description.split('<hammer>')[0] + '<hammer>'
 
     def _parse_proof_context(self, proof_context_str: str, local_hypotheses: typing.List[IsabelleLemma], found_lemma: bool) -> ProofContext:
         if proof_context_str is None or len(proof_context_str) == 0:

--- a/src/tools/isabelle_executor.py
+++ b/src/tools/isabelle_executor.py
@@ -16,6 +16,7 @@ import threading
 from collections import OrderedDict
 from pathlib import Path
 from src.pisa.src.main.python.pisa_client import PisaEnv, initialise_env, IsabelleLemma
+from src.rl.proof_action import ProofAction
 from src.tools.isabelle_parse_utils import IsabelleLineByLineReader, IsabelleStepByStepStdInReader
 logger = logging.getLogger()
 
@@ -111,7 +112,7 @@ class IsabelleExecutor:
     auto_tactics = ["auto", "simp", "blast", "fastforce", "force", "eval", "presburger", "sos", "arith", "linarith", "(auto simp: field_simps)",
                     "metis", "argo", "algebra", "fast", "meson", "satx"]
 
-    def __init__(self, project_root: str = None, main_file: str = None, use_hammer: bool = True, timeout_in_sec: int = 60, 
+    def __init__(self, project_root: str = None, main_file: str = None, use_hammer: ProofAction.HammerMode = ProofAction.HammerMode.AUTO, timeout_in_sec: int = 60, 
                  use_human_readable_proof_context: bool = False, proof_step_iter: typing.Iterator[str] = None, 
                  suppress_error_log: bool = False, port: int = 8000):
         assert proof_step_iter is None or isinstance(proof_step_iter, typing.Iterator), \
@@ -581,7 +582,7 @@ class IsabelleExecutor:
                 temp_start = start_state
             
             if tactic == 'sledgehammer':
-                if proof_search_mode and not self.use_hammer:
+                if proof_search_mode and self.use_hammer == ProofAction.HammerMode.NONE:
                     raise Exception('Error: got "sledgehammer" query with hammer turned off. To use hammer, toggle "use_hammer"')
  
                 # Attempt to solve proof with sledgehammer

--- a/src/tools/proof_exec_callback.py
+++ b/src/tools/proof_exec_callback.py
@@ -24,7 +24,7 @@ class ProofExecutorCallback(object):
                 file_path: str,
                 language: ProofAction.Language = ProofAction.Language.COQ,
                 prefix: str = None,
-                use_hammer: bool = False,
+                use_hammer: ProofAction.HammerMode = ProofAction.HammerMode.ALLOW,
                 timeout_in_secs: int = 60,
                 use_human_readable_proof_context: bool = True,
                 suppress_error_log: bool = True,
@@ -46,13 +46,15 @@ class ProofExecutorCallback(object):
 
     def get_proof_executor(self) -> typing.Union[DynamicCoqProofExecutor, DynamicLeanProofExecutor, DynamicIsabelleProofExecutor]:
         if self.language == ProofAction.Language.COQ:
-            search_exec = CoqExecutor(self.project_folder, self.file_path, use_hammer=self.use_hammer, timeout_in_sec=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context)
+            use_hammer = self.use_hammer == ProofAction.HammerMode.AUTO or self.use_hammer == ProofAction.HammerMode.ONESHOT
+            search_exec = CoqExecutor(self.project_folder, self.file_path, use_hammer=use_hammer, timeout_in_sec=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context)
             coq_context_helper = CoqContextHelper(search_exec, self.search_depth, logger=self.logger)
-            return DynamicCoqProofExecutor(coq_context_helper, self.project_folder, self.file_path, context_type=DynamicCoqProofExecutor.ContextType.BestContext, use_hammer=self.use_hammer, timeout_in_seconds=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context)
+            return DynamicCoqProofExecutor(coq_context_helper, self.project_folder, self.file_path, context_type=DynamicCoqProofExecutor.ContextType.BestContext, use_hammer=use_hammer, timeout_in_seconds=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context)
         elif self.language == ProofAction.Language.LEAN:
-            search_exec = Lean3Executor(self.project_folder, self.prefix, self.file_path, use_hammer=self.use_hammer, timeout_in_sec=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context, enable_search=self.always_use_retrieval)
+            use_hammer = self.use_hammer == ProofAction.HammerMode.AUTO or self.use_hammer == ProofAction.HammerMode.ONESHOT
+            search_exec = Lean3Executor(self.project_folder, self.prefix, self.file_path, use_hammer=use_hammer, timeout_in_sec=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context, enable_search=self.always_use_retrieval)
             lean_context_helper = Lean3ContextHelper(search_exec, self.search_depth, logger=self.logger)
-            return DynamicLeanProofExecutor(lean_context_helper, self.project_folder, self.file_path, context_type=DynamicLeanProofExecutor.ContextType.NoContext, use_hammer=self.use_hammer, timeout_in_seconds=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context)
+            return DynamicLeanProofExecutor(lean_context_helper, self.project_folder, self.file_path, context_type=DynamicLeanProofExecutor.ContextType.NoContext, use_hammer=use_hammer, timeout_in_seconds=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context)
         elif self.language == ProofAction.Language.ISABELLE:
             search_exec = IsabelleExecutor(self.project_folder, self.file_path, use_hammer=self.use_hammer, timeout_in_sec=self.timeout_in_secs, suppress_error_log=self.suppress_error_log, use_human_readable_proof_context=self.use_human_readable_proof_context)
             isabelle_context_helper = IsabelleContextHelper(search_exec, self.search_depth, logger=self.logger)


### PR DESCRIPTION
This PR does two things:
- Introduces HammerMode, an enum for specifying hammer configs for experiments. Set `use_hammer` to `NONE, ALLOW, AUTO, ONESHOT` instead of using booleans. For backwards compatibility: `NONE, ALLOW` interpreted as false, `AUTO, ONESHOT` interpreted as true
- Pipeline will now replace sledgehammer queries by the actual tactics generated. For example, a resulting proof might look like this -- 
```
lemma basic_arithmetic:
fixes x::real
shows "(x+y)*(x+2*y)*(x+3*y) = x^3 + 6*x^2*y + 11*x*y^2 + 6*y^3"
show ?thesis by sos <auto tactic>
qed
```
or 
```
lemma sqrt_comp: "sqrt 2 + sqrt 3 < sqrt 10"
have "(2 * (sqrt 2 * sqrt 3))^2 < 5 ^ 2" by (simp add: algebra_simps eval_nat_numeral)
  then have "2 * (sqrt 2 * sqrt 3) < 5" using power_less_imp_less_base zero_le_numeral by blast <hammer>
  then have "(sqrt 2 + sqrt 3)^2 < (sqrt 10)^2" by (simp add: algebra_simps eval_nat_numeral)
  then show ?thesis using power_less_imp_less_base real_sqrt_ge_zero zero_le_numeral by blast <hammer>
qed
```