### PR TITLE
Automatically attempt sledgehammer on failed tactic

### DIFF
--- a/src/main/config/eval_settings/n_4_few_gpt35.yaml
+++ b/src/main/config/eval_settings/n_4_few_gpt35.yaml
@@ -1,6 +1,6 @@
 name: n_4_few_gpt35
 setting_type: Agent
-use_hammer: ALLOW
+use_hammer: AUTO
 max_proof_depth: 100
 timeout_in_secs: 60
 proof_retries: 1

--- a/src/main/config/eval_settings/n_60_dfs_gpt35_always_retrieve_no_ex.yaml
+++ b/src/main/config/eval_settings/n_60_dfs_gpt35_always_retrieve_no_ex.yaml
@@ -1,6 +1,6 @@
 name: n_60_dfs_gpt35_always_retrieve_no_ex
 setting_type: Agent
-use_hammer: ALLOW
+use_hammer: AUTO
 max_proof_depth: 100
 timeout_in_secs: 60 # coq tactic execution timeout
 proof_retries: 1

--- a/src/tools/dynamic_isabelle_proof_exec.py
+++ b/src/tools/dynamic_isabelle_proof_exec.py
@@ -88,7 +88,7 @@ class DynamicProofExecutor(IsabelleExecutor):
             return -1
 
 
-    def __init__(self, isabelle_context_helper: IsabelleContextHelper, project_folder: str = None, proof_file: str = None, instruction_iter: typing.Optional[str] = None, use_hammer: ProofAction.HammerMode = ProofAction.HammerMode.ALLOW, timeout_in_seconds: int = 60, use_human_readable_proof_context: bool = True, suppress_error_log: bool = True, context_type: ContextType = ContextType.NoContext):
+    def __init__(self, isabelle_context_helper: IsabelleContextHelper, project_folder: str = None, proof_file: str = None, instruction_iter: typing.Optional[str] = None, use_hammer: ProofAction.HammerMode = ProofAction.HammerMode.AUTO, timeout_in_seconds: int = 60, use_human_readable_proof_context: bool = True, suppress_error_log: bool = True, context_type: ContextType = ContextType.NoContext):
         assert proof_file is None or os.path.exists(proof_file), f"Proof file {proof_file} does not exist"
         assert isabelle_context_helper is not None, "isabelle_context_helper must not be None"
         self.proof_file = proof_file


### PR DESCRIPTION
Following the style of LYRA, automatically run sledgehammer + heuristics when the agent-provided proof tactic fails